### PR TITLE
improvement: Add datetime.datetime as a possible argument to DateField.to_python

### DIFF
--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -79,6 +79,8 @@ class DateField(Field):
     def to_python(self, value):
         if isinstance(value, datetime.date):
             return value
+        if isinstance(value, datetime.datetime):
+            return value.date()
         if isinstance(value, int):
             return DateField.class_default + datetime.timedelta(days=value)
         if isinstance(value, string_types):


### PR DESCRIPTION
As for my short experience of working with ClickHouse, you will need to have a ‘Date’ field in all of your table. To prove my point, lets see the offical documentation:
“The most advanced ClickHouse engine (MergeTree) requires a separate field containing the date, and the field must be of  'Date' type (not 'DateTime').”
The time im python is commonly stored stored in datetime structure, so it will be very handy, if you could pass the DateTime object directly to Date handler, without making unobvious date.date() conversion.
