### PR TITLE
GROUP BY WITH TOTALS workaround to skip blank line separator

### DIFF
--- a/src/infi/clickhouse_orm/database.py
+++ b/src/infi/clickhouse_orm/database.py
@@ -96,7 +96,9 @@ class Database(object):
         field_types = parse_tsv(next(lines))
         model_class = model_class or ModelBase.create_ad_hoc_model(zip(field_names, field_types))
         for line in lines:
-            yield model_class.from_tsv(line, field_names, self.server_timezone, self)
+            # skip blank line left by WITH TOTALS modifier
+            if line:
+                yield model_class.from_tsv(line, field_names, self.server_timezone, self)
 
     def raw(self, query, settings=None, stream=False):
         """

--- a/src/infi/clickhouse_orm/utils.py
+++ b/src/infi/clickhouse_orm/utils.py
@@ -38,7 +38,14 @@ def unescape(value):
 def parse_tsv(line):
     if PY3 and isinstance(line, binary_type):
         line = line.decode()
-    if line[-1] == '\n':
+    # GROUP BY WITH TOTALS modifier contains a blank line (second last row)
+    # separating normal result from the totals (last row)
+    # Let's skip the blank line
+    try:
+        last_element = line[-1]
+    except IndexError:
+        return
+    if last_element == '\n':
         line = line[:-1]
     return [unescape(value) for value in line.split('\t')]
 


### PR DESCRIPTION
[WITH TOTALS](https://clickhouse.yandex/reference_en.html#WITH TOTALS modifier) modifier for `GROUP BY` contains a blank line as a separator (second last result row) between normal rows and totals (last result row). It's making ORM crash. That's been fixed with this PR.

It seems that changes made doesn't affect performance that much.