### PR TITLE
blank datetime fix

### DIFF
--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -137,7 +137,7 @@ class DateTimeField(Field):
         raise ValueError('Invalid value for %s - %r' % (self.__class__.__name__, value))
 
     def to_db_string(self, value, quote=True):
-        return escape(timegm(value.utctimetuple()) or '0000000000', quote)
+        return escape(('0000000000' + str(timegm(value.utctimetuple())))[-10:], quote)
 
 
 class BaseIntField(Field):

--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -137,7 +137,7 @@ class DateTimeField(Field):
         raise ValueError('Invalid value for %s - %r' % (self.__class__.__name__, value))
 
     def to_db_string(self, value, quote=True):
-        return escape(('0000000000' + str(timegm(value.utctimetuple())))[-10:], quote)
+        return escape('%010d' % (timegm(value.utctimetuple())), quote)
 
 
 class BaseIntField(Field):

--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -137,7 +137,7 @@ class DateTimeField(Field):
         raise ValueError('Invalid value for %s - %r' % (self.__class__.__name__, value))
 
     def to_db_string(self, value, quote=True):
-        return escape(timegm(value.utctimetuple()), quote)
+        return escape(timegm(value.utctimetuple()) or '0000000000', quote)
 
 
 class BaseIntField(Field):

--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -137,7 +137,7 @@ class DateTimeField(Field):
         raise ValueError('Invalid value for %s - %r' % (self.__class__.__name__, value))
 
     def to_db_string(self, value, quote=True):
-        return escape('%010d' % (timegm(value.utctimetuple())), quote)
+        return escape('%010d' % timegm(value.utctimetuple()), quote)
 
 
 class BaseIntField(Field):


### PR DESCRIPTION
In new clickhouse version need 0000000000 instead 0 values in blank datetime. This is small fix.

```
ERROR: garbage after DateTime: "xxxxx<TAB>"
ERROR: DateTime must be in YYYY-MM-DD hh:mm:ss or NNNNNNNNNN (unix timestamp, exactly 10 digits) format.

, e.what() = DB::Exception
```