### PR TITLE
fix unicode params for Py2

### DIFF
--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -18,9 +18,9 @@ class Field(object):
     def __init__(self, default=None, alias=None, materialized=None):
         assert (None, None) in {(default, alias), (alias, materialized), (default, materialized)}, \
             "Only one of default, alias and materialized parameters can be given"
-        assert alias is None or isinstance(alias, str) and alias != "",\
+        assert alias is None or isinstance(alias, string_types) and alias != "",\
             "Alias field must be string field name, if given"
-        assert materialized is None or isinstance(materialized, str) and alias != "",\
+        assert materialized is None or isinstance(materialized, string_types) and alias != "",\
             "Materialized field must be string, if given"
 
         self.creation_counter = Field.creation_counter

--- a/src/infi/clickhouse_orm/system_models.py
+++ b/src/infi/clickhouse_orm/system_models.py
@@ -2,6 +2,8 @@
 This file contains system readonly models that can be got from database
 https://clickhouse.yandex/reference_en.html#System tables
 """
+from six import string_types
+
 from .database import Database
 from .fields import *
 from .models import Model
@@ -115,7 +117,7 @@ class SystemPart(Model):
         :return: A list of SystemPart objects
         """
         assert isinstance(database, Database), "database must be database.Database class instance"
-        assert isinstance(conditions, str), "conditions must be a string"
+        assert isinstance(conditions, string_types), "conditions must be a string"
         if conditions:
             conditions += " AND"
         field_names = ','.join([f[0] for f in cls._fields])

--- a/tests/test_alias_fields.py
+++ b/tests/test_alias_fields.py
@@ -60,7 +60,7 @@ class ModelWithAliasFields(Model):
     date_field = DateField()
     str_field = StringField()
 
-    alias_str = StringField(alias='str_field')
+    alias_str = StringField(alias=u'str_field')
     alias_int = Int32Field(alias='int_field')
     alias_date = DateField(alias='date_field')
 

--- a/tests/test_materialized_fields.py
+++ b/tests/test_materialized_fields.py
@@ -62,7 +62,7 @@ class ModelWithMaterializedFields(Model):
 
     mat_str = StringField(materialized='lower(str_field)')
     mat_int = Int32Field(materialized='abs(int_field)')
-    mat_date = DateField(materialized='toDate(date_time_field)')
+    mat_date = DateField(materialized=u'toDate(date_time_field)')
 
     engine = MergeTree('mat_date', ('mat_date',))
 

--- a/tests/test_system_models.py
+++ b/tests/test_system_models.py
@@ -40,7 +40,7 @@ class SystemPartTest(unittest.TestCase):
     def test_get_conditions(self):
         parts = list(SystemPart.get(self.database, conditions="table='testtable'"))
         self.assertEqual(len(parts), 1)
-        parts = list(SystemPart.get(self.database, conditions="table='othertable'"))
+        parts = list(SystemPart.get(self.database, conditions=u"table='othertable'"))
         self.assertEqual(len(parts), 0)
 
     def test_attach_detach(self):


### PR DESCRIPTION
fixes some assertion failures when using `from __future__ import unicode_literals` in Py2