### PR TITLE
Fixed 2 bugs in Merge engine

### DIFF
--- a/src/infi/clickhouse_orm/engines.py
+++ b/src/infi/clickhouse_orm/engines.py
@@ -146,10 +146,11 @@ class Merge(Engine):
         self.table_regex = table_regex
 
         # Use current database as default
-        self.db_name = 'currentDatabase()'
+        self.db_name = None
 
     def create_table_sql(self):
-        return "Merge(%s, '%s')" % (self.db_name, self.table_regex)
+        db_name = ("`%s`" % self.db_name) if self.db_name else 'currentDatabase()'
+        return "Merge(%s, '%s')" % (db_name, self.table_regex)
 
     def set_db_name(self, db_name):
         assert isinstance(db_name, six.string_types), "'db_name' parameter must be string"

--- a/src/infi/clickhouse_orm/models.py
+++ b/src/infi/clickhouse_orm/models.py
@@ -274,3 +274,9 @@ class MergeModel(Model):
         res = super(MergeModel, self).set_database(db)
         self.engine.set_db_name(db.db_name)
         return res
+
+    @classmethod
+    def create_table_sql(cls, db_name):
+        assert isinstance(cls.engine, Merge), "engine must be engines.Merge instance"
+        cls.engine.set_db_name(db_name)
+        return super(MergeModel, cls).create_table_sql(db_name)


### PR DESCRIPTION
1) If database name contained some signes (+, -) create merge table failed.
2) When merge table was created and set_database was not previously called, "currentDatabase()" was also used, which could lead to errors on multiple databases.