### PR TITLE
Allow ISO-formatted datetime. Enable skipped test.  Show field name in error when invalid value assigned.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -10,6 +10,7 @@ name = infi.clickhouse_orm
 company = Infinidat
 namespace_packages = ['infi']
 install_requires = [
+	'iso8601 >= 0.1.12',
 	'pytz',
 	'requests',
 	'setuptools',

--- a/docs/field_types.md
+++ b/docs/field_types.md
@@ -32,7 +32,7 @@ A `DateTimeField` can be assigned values from one of the following types:
 -   datetime
 -   date
 -   integer - number of seconds since the Unix epoch
--   string in `YYYY-MM-DD HH:MM:SS` format
+-   string in `YYYY-MM-DD HH:MM:SS` format or [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-compatible format
 
 The assigned value always gets converted to a timezone-aware `datetime` in UTC. If the assigned value is a timezone-aware `datetime` in another timezone, it will be converted to UTC. Otherwise, the assigned value is assumed to already be in UTC.
 

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -24,7 +24,6 @@ class JoinTest(unittest.TestCase):
         self.print_res("SELECT * FROM {}".format(Bar.table_name()))
         self.print_res("SELECT b FROM {} ALL LEFT JOIN {} USING id".format(Foo.table_name(), Bar.table_name()))
 
-    @unittest.skip('ClickHouse issue - https://github.com/yandex/ClickHouse/issues/635')
     def test_with_db_name(self):
         self.print_res("SELECT * FROM $db.{}".format(Foo.table_name()))
         self.print_res("SELECT * FROM $db.{}".format(Bar.table_name()))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -79,6 +79,27 @@ class ModelTestCase(unittest.TestCase):
                 "datetime_field": datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=pytz.utc)
             })
 
+    def test_field_name_in_error_message_for_invalid_value_in_constructor(self):
+        bad_value = 1
+        with self.assertRaises(ValueError) as cm:
+            SimpleModel(str_field=bad_value)
+
+        self.assertEqual(
+            "Invalid value for StringField: {} (field 'str_field')".format(repr(bad_value)),
+            text_type(cm.exception)
+        )
+
+    def test_field_name_in_error_message_for_invalid_value_in_assignment(self):
+        instance = SimpleModel()
+        bad_value = 'foo'
+        with self.assertRaises(ValueError) as cm:
+            instance.float_field = bad_value
+
+        self.assertEqual(
+            "Invalid value for Float32Field - {} (field 'float_field')".format(repr(bad_value)),
+            text_type(cm.exception)
+        )
+
 
 class SimpleModel(Model):
 

--- a/tests/test_simple_fields.py
+++ b/tests/test_simple_fields.py
@@ -13,14 +13,17 @@ class SimpleFieldsTest(unittest.TestCase):
         # Valid values
         for value in (date(1970, 1, 1), datetime(1970, 1, 1), epoch,
                       epoch.astimezone(pytz.timezone('US/Eastern')), epoch.astimezone(pytz.timezone('Asia/Jerusalem')),
-                      '1970-01-01 00:00:00', '1970-01-17 00:00:17', '0000-00-00 00:00:00', 0):
+                      '1970-01-01 00:00:00', '1970-01-17 00:00:17', '0000-00-00 00:00:00', 0,
+                      '2017-07-26T08:31:05', '2017-07-26T08:31:05Z', '2017-07-26 08:31',
+                      '2017-07-26T13:31:05+05', '2017-07-26 13:31:05+0500'):
             dt = f.to_python(value, pytz.utc)
             self.assertEquals(dt.tzinfo, pytz.utc)
             # Verify that conversion to and from db string does not change value
             dt2 = f.to_python(f.to_db_string(dt, quote=False), pytz.utc)
             self.assertEquals(dt, dt2)
         # Invalid values
-        for value in ('nope', '21/7/1999', 0.5):
+        for value in ('nope', '21/7/1999', 0.5,
+                      '2017-01 15:06:00', '2017-01-01X15:06:00', '2017-13-01T15:06:00'):
             with self.assertRaises(ValueError):
                 f.to_python(value, pytz.utc)
 
@@ -48,6 +51,19 @@ class SimpleFieldsTest(unittest.TestCase):
         f = DateField()
         dt = datetime(2017, 10, 5, tzinfo=pytz.timezone('Asia/Jerusalem'))
         self.assertEquals(f.to_python(dt, pytz.utc), date(2017, 10, 4))
+
+    def test_datetime_field_timezone(self):
+        # Verify that conversion of timezone-aware datetime is correct
+        f = DateTimeField()
+        utc_value = datetime(2017, 7, 26, 8, 31, 5, tzinfo=pytz.UTC)
+        for value  in (
+                '2017-07-26T08:31:05',
+                '2017-07-26T08:31:05Z',
+                '2017-07-26T11:31:05+03',
+                '2017-07-26 11:31:05+0300',
+                '2017-07-26T03:31:05-0500',
+        ):
+            self.assertEquals(f.to_python(value, pytz.utc), utc_value)
 
     def test_uint8_field(self):
         f = UInt8Field()


### PR DESCRIPTION
Fixes #43