### PR TITLE
Improve testing, change Model._fields, Distributed engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ src/infi/clickhouse_orm/__version__.py
 bootstrap.py
 
 htmldocs/
+
+# tox
+.tox/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -30,6 +30,10 @@ To see test coverage information run:
 
     bin/nosetests --with-coverage --cover-package=infi.clickhouse_orm
 
+To test with tox, ensure that the setup.py is present (otherwise run `bin/buildout buildout:develop= setup.py`) and run:
+
+    pip install tox
+    tox
 
 ---
 

--- a/docs/table_engines.md
+++ b/docs/table_engines.md
@@ -16,6 +16,7 @@ The following engines are supported by the ORM:
 - ReplacingMergeTree / ReplicatedReplacingMergeTree
 - Buffer
 - Merge
+- Distributed
 
 
 Simple Engines

--- a/src/infi/clickhouse_orm/database.py
+++ b/src/infi/clickhouse_orm/database.py
@@ -148,7 +148,7 @@ class Database(object):
             raise DatabaseException("You can't insert into read only and system tables")
 
         fields_list = ','.join(
-            ['`%s`' % name for name, _ in first_instance._writable_fields])
+            ['`%s`' % name for name in first_instance.fields(writable=True)])
 
         def gen():
             buf = BytesIO()

--- a/src/infi/clickhouse_orm/system_models.py
+++ b/src/infi/clickhouse_orm/system_models.py
@@ -126,7 +126,7 @@ class SystemPart(Model):
         assert isinstance(conditions, string_types), "conditions must be a string"
         if conditions:
             conditions += " AND"
-        field_names = ','.join([f[0] for f in cls._fields])
+        field_names = ','.join(cls.fields())
         return database.select("SELECT %s FROM %s WHERE %s database='%s'" %
                                (field_names,  cls.table_name(), conditions, database.db_name), model_class=cls)
 

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -33,7 +33,9 @@ class EnginesTestCase(_EnginesHelperTestCase):
 
     def test_merge_tree_with_sampling(self):
         class TestModel(SampleModel):
-            engine = MergeTree('date', ('date', 'event_id', 'event_group'), sampling_expr='intHash32(event_id)')
+            engine = MergeTree('date',
+                               ('date', 'event_id', 'event_group', 'intHash32(event_id)'),
+                               sampling_expr='intHash32(event_id)')
         self._create_and_insert(TestModel)
 
     def test_merge_tree_with_granularity(self):

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 import unittest
 
-from infi.clickhouse_orm.database import Database, DatabaseException
-from infi.clickhouse_orm.models import Model, MergeModel
+from infi.clickhouse_orm.database import Database, DatabaseException, ServerError
+from infi.clickhouse_orm.models import Model, MergeModel, DistributedModel
 from infi.clickhouse_orm.fields import *
 from infi.clickhouse_orm.engines import *
 
@@ -10,7 +10,7 @@ import logging
 logging.getLogger("requests").setLevel(logging.WARNING)
 
 
-class EnginesTestCase(unittest.TestCase):
+class _EnginesHelperTestCase(unittest.TestCase):
 
     def setUp(self):
         self.database = Database('test-db')
@@ -18,6 +18,8 @@ class EnginesTestCase(unittest.TestCase):
     def tearDown(self):
         self.database.drop_database()
 
+
+class EnginesTestCase(_EnginesHelperTestCase):
     def _create_and_insert(self, model_class):
         self.database.create_table(model_class)
         self.database.insert([
@@ -133,3 +135,134 @@ class SampleModel(Model):
     event_count     = UInt16Field()
     event_version   = Int8Field()
     event_uversion  = UInt8Field(materialized='abs(event_version)')
+
+
+class DistributedTestCase(_EnginesHelperTestCase):
+    def test_without_table_name(self):
+        engine = Distributed('my_cluster')
+
+        with self.assertRaises(ValueError) as cm:
+            engine.create_table_sql()
+
+        exc = cm.exception
+        self.assertEqual(str(exc), 'Cannot create Distributed engine: specify an underlying table')
+
+    def test_with_table_name(self):
+        engine = Distributed('my_cluster', 'foo')
+        sql = engine.create_table_sql()
+        self.assertEqual(sql, 'Distributed(my_cluster, currentDatabase(), foo)')
+
+    class TestModel(SampleModel):
+        engine = TinyLog()
+
+    def _create_distributed(self, shard_name, underlying=TestModel):
+        class TestDistributedModel(DistributedModel, underlying):
+            engine = Distributed(shard_name, underlying)
+
+        self.database.create_table(underlying)
+        self.database.create_table(TestDistributedModel)
+        return TestDistributedModel
+
+    def test_bad_cluster_name(self):
+        d_model = self._create_distributed('cluster_name')
+        with self.assertRaises(ServerError) as cm:
+            self.database.count(d_model)
+
+        exc = cm.exception
+        self.assertEqual(exc.code, 170)
+        self.assertEqual(exc.message, "Requested cluster 'cluster_name' not found")
+
+    def test_verbose_engine_two_superclasses(self):
+        class TestModel2(SampleModel):
+            engine = Log()
+
+        class TestDistributedModel(DistributedModel, self.TestModel, TestModel2):
+            engine = Distributed('test_shard_localhost', self.TestModel)
+
+        self.database.create_table(self.TestModel)
+        self.database.create_table(TestDistributedModel)
+        self.assertEqual(self.database.count(TestDistributedModel), 0)
+
+    def test_minimal_engine(self):
+        class TestDistributedModel(DistributedModel, self.TestModel):
+            engine = Distributed('test_shard_localhost')
+
+        self.database.create_table(self.TestModel)
+        self.database.create_table(TestDistributedModel)
+
+        self.assertEqual(self.database.count(TestDistributedModel), 0)
+
+    def test_minimal_engine_two_superclasses(self):
+        class TestModel2(SampleModel):
+            engine = Log()
+
+        class TestDistributedModel(DistributedModel, self.TestModel, TestModel2):
+            engine = Distributed('test_shard_localhost')
+
+        self.database.create_table(self.TestModel)
+        with self.assertRaises(TypeError) as cm:
+            self.database.create_table(TestDistributedModel)
+
+        exc = cm.exception
+        self.assertEqual(str(exc), 'When defining Distributed engine without the table_name ensure '
+                                   'that your model has exactly one non-distributed superclass')
+
+    def test_minimal_engine_no_superclasses(self):
+        class TestDistributedModel(DistributedModel):
+            engine = Distributed('test_shard_localhost')
+
+        self.database.create_table(self.TestModel)
+        with self.assertRaises(TypeError) as cm:
+            self.database.create_table(TestDistributedModel)
+
+        exc = cm.exception
+        self.assertEqual(str(exc), 'When defining Distributed engine without the table_name ensure '
+                                   'that your model has a parent model')
+
+    def _test_insert_select(self, local_to_distributed, test_model=TestModel, include_readonly=True):
+        d_model = self._create_distributed('test_shard_localhost', underlying=test_model)
+
+        if local_to_distributed:
+            to_insert, to_select = test_model, d_model
+        else:
+            to_insert, to_select = d_model, test_model
+
+        self.database.insert([
+            to_insert(date='2017-01-01', event_id=1, event_group=1, event_count=1, event_version=1),
+            to_insert(date='2017-01-02', event_id=2, event_group=2, event_count=2, event_version=2)
+        ])
+        # event_uversion is materialized field. So * won't select it and it will be zero
+        res = self.database.select('SELECT *, event_uversion FROM $table ORDER BY event_id',
+                                   model_class=to_select)
+        res = [row for row in res]
+        self.assertEqual(2, len(res))
+        self.assertDictEqual({
+            'date': datetime.date(2017, 1, 1),
+            'event_id': 1,
+            'event_group': 1,
+            'event_count': 1,
+            'event_version': 1,
+            'event_uversion': 1
+        }, res[0].to_dict(include_readonly=include_readonly))
+        self.assertDictEqual({
+            'date': datetime.date(2017, 1, 2),
+            'event_id': 2,
+            'event_group': 2,
+            'event_count': 2,
+            'event_version': 2,
+            'event_uversion': 2
+        }, res[1].to_dict(include_readonly=include_readonly))
+
+    @unittest.skip("Bad support of materialized fields in Distributed tables "
+                   "https://groups.google.com/forum/#!topic/clickhouse/XEYRRwZrsSc")
+    def test_insert_distributed_select_local(self):
+        return self._test_insert_select(local_to_distributed=False)
+
+    def test_insert_local_select_distributed(self):
+        return self._test_insert_select(local_to_distributed=True)
+
+    def _test_insert_distributed_select_local_no_materialized_fields(self):
+        class TestModel2(self.TestModel):
+            event_uversion = UInt8Field(readonly=True)
+
+        return self._test_insert_select(local_to_distributed=False, test_model=TestModel2, include_readonly=False)

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -166,8 +166,8 @@ class DistributedTestCase(_EnginesHelperTestCase):
         return TestDistributedModel
 
     def test_bad_cluster_name(self):
-        d_model = self._create_distributed('cluster_name')
         with self.assertRaises(ServerError) as cm:
+            d_model = self._create_distributed('cluster_name')
             self.database.count(d_model)
 
         exc = cm.exception

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -11,7 +11,7 @@ from infi.clickhouse_orm.engines import *
 class InheritanceTestCase(unittest.TestCase):
 
     def assertFieldNames(self, model_class, names):
-        self.assertEquals(names, [name for name, field in model_class._fields])
+        self.assertEquals(names, list(model_class.fields()))
 
     def test_field_inheritance(self):
         self.assertFieldNames(ParentModel, ['date_field', 'int_field'])

--- a/tests/test_readonly.py
+++ b/tests/test_readonly.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from infi.clickhouse_orm.database import DatabaseException
+from infi.clickhouse_orm.database import DatabaseException, ServerError
 from .base_test_with_data import *
 
 
@@ -12,21 +12,30 @@ class ReadonlyTestCase(TestCaseWithData):
         orig_database = self.database
         try:
             self.database = Database(orig_database.db_name, username=username, readonly=True)
-            with self.assertRaises(DatabaseException):
+            with self.assertRaises(ServerError) as cm:
                 self._insert_and_check(self._sample_data(), len(data))
+            self._check_db_readonly_err(cm.exception)
+
             self.assertEquals(self.database.count(Person), 100)
             list(self.database.select('SELECT * from $table', Person))
-            with self.assertRaises(DatabaseException):
+            with self.assertRaises(ServerError) as cm:
                 self.database.drop_table(Person)
-            with self.assertRaises(DatabaseException):
+            self._check_db_readonly_err(cm.exception)
+
+            with self.assertRaises(ServerError) as cm:
                 self.database.drop_database()
-        except DatabaseException as e:
-            if 'Unknown user' in six.text_type(e):
+            self._check_db_readonly_err(cm.exception)
+        except ServerError as e:
+            if e.code == 192 and e.message.startswith('Unknown user'):
                 raise unittest.SkipTest('Database user "%s" is not defined' % username)
             else:
                 raise
         finally:
             self.database = orig_database
+
+    def _check_db_readonly_err(self, exc):
+        self.assertEqual(exc.code, 164)
+        self.assertEqual(exc.message, 'Cannot execute query in readonly mode')
 
     def test_readonly_db_with_default_user(self):
         self._test_readonly_db('default')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35
+envlist = py27, py35, pypy
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27, py35
+
+[testenv]
+deps =
+    nose
+    flake8
+
+commands =
+    {envpython} -m compileall -q src/ tests/
+    # {envbindir}/flake8 src/ tests/ --max-line-length=120
+    nosetests -v {posargs}


### PR DESCRIPTION
This update can potentially break the old code which uses `Model._fields` or `Model._writable_fields` but I think that's not so bad since they are for class internal usage (started with an underscore). However `Model._fields` represented as an `OrderedDict` is way more convenient than the previous list of pairs and also preserves order.

Also I could not find a way to install `tox` automatically as I do not have experience with buildout, but tox really simplifies testing for py2 and py3 (I use this library in a cross-versioned project).

The new `ServerError` exception is backward compatible with `DatabaseException` so it should not be troubles with it.

And Distributed engine can be helpful for those who want to use clustered environment.