### PR TITLE
Add support for compound filters with Q objects

### DIFF
--- a/docs/querysets.md
+++ b/docs/querysets.md
@@ -26,6 +26,12 @@ It is possible to specify several fields to filter or exclude by:
     >>> qs.conditions_as_sql()
     u"last_name = 'Smith' AND height > 1.75"
 
+For filters with compound conditions you can use `Q` objects inside `filter` with overloaded operators `&` (AND), `|` (OR) and `~` (NOT):
+
+    >>> qs = Person.objects_in(database).filter((Q(first_name='Ciaran', last_name='Carver') | Q(height_lte=1.8)) & ~Q(first_name='David'))
+    >>> qs.conditions_as_sql()
+    u"((first_name = 'Ciaran' AND last_name = 'Carver') OR height <= 1.8) AND (NOT (first_name = 'David'))"
+
 There are different operators that can be used, by passing `<fieldname>__<operator>=<value>` (two underscores separate the field name from the operator). In case no operator is given, `eq` is used by default. Below are all the supported operators.
 
 | Operator       | Equivalent SQL                               | Comments                           |
@@ -36,6 +42,7 @@ There are different operators that can be used, by passing `<fieldname>__<operat
 | `gte`          | `field >= value`                             |                                    |
 | `lt`           | `field < value`                              |                                    |
 | `lte`          | `field <= value`                             |                                    |
+| `between`      | `field BETWEEN value1 AND value2`            |                                    |
 | `in`           | `field IN (values)`                          | See below                          |
 | `not_in`       | `field NOT IN (values)`                      | See below                          |
 | `contains`     | `field LIKE '%value%'`                       | For string fields only             |

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals, print_function
 import unittest
 
 from infi.clickhouse_orm.database import Database
+from infi.clickhouse_orm.query import Q
 from .base_test_with_data import *
 import logging
 from datetime import date, datetime
@@ -58,6 +59,15 @@ class QuerySetTestCase(TestCaseWithData):
         self._test_qs(qs.filter(first_name__endswith='IA'), 0) # case sensitive
         self._test_qs(qs.filter(first_name__iendswith='ia'), 3) # case insensitive
         self._test_qs(qs.filter(first_name__iendswith=''), 100) # empty suffix
+
+    def test_filter_with_q_objects(self):
+        qs = Person.objects_in(self.database)
+        self._test_qs(qs.filter(Q(first_name='Ciaran')), 2)
+        self._test_qs(qs.filter(Q(first_name='Ciaran') | Q(first_name='Chelsea')), 3)
+        self._test_qs(qs.filter(Q(first_name__in=['Warren', 'Whilemina', 'Whitney']) & Q(height__gte=1.7)), 3)
+        self._test_qs(qs.filter((Q(first_name__in=['Warren', 'Whilemina', 'Whitney']) & Q(height__gte=1.7) |
+                                 (Q(first_name__in=['Victoria', 'Victor', 'Venus']) & Q(height__lt=1.7)))), 4)
+        self._test_qs(qs.filter(Q(first_name='Elton') & ~Q(last_name='Smith')), 1)
 
     def test_filter_unicode_string(self):
         self.database.insert([


### PR DESCRIPTION
Added support for method `filter` take ` Q` objects with overloaded operators `&` (AND), `|` (OR) and `~` (NOT).
Added BETWEEN operator.