### PR TITLE
Add disabler for the timezone getting

### DIFF
--- a/src/infi/clickhouse_orm/database.py
+++ b/src/infi/clickhouse_orm/database.py
@@ -98,7 +98,7 @@ class Database(object):
             self.create_database()
         self.server_version = self._get_server_version()
         # Versions 1.1.53981 and below don't have timezone function
-        self.server_timezone = self._get_server_timezone() if self.server_version[2] > 53981 else pytz.utc
+        self.server_timezone = self._get_server_timezone() if self.server_version > (1, 1, 53981) else pytz.utc
 
     def create_database(self):
         '''


### PR DESCRIPTION
We have a lot of CH stack traces while working:

```
2018-05-08 12:16:07,258 ERROR Cannot determine server timezone, assuming UTC
--
12:16:07 Traceback (most recent call last):
12:16:07   File "/usr/lib/python2.7/targettest-api/infi/clickhouse_orm/database.py", line 282, in _get_server_timezone
12:16:07     r = self._send('SELECT timezone()')
12:16:07   File "/usr/lib/python2.7/targettest-api/infi/clickhouse_orm/database.py", line 253, in _send
12:16:07     raise DatabaseException(r.text)
12:16:07 DatabaseException: Code: 46, e.displayText() = DB::Exception: Unknown function timezone, e.what() = DB::Exception, Stack trace:
12:16:07
12:16:07 0. clickhouse-server(StackTrace::StackTrace()+0xe) [0xfae31e]
12:16:07 1. clickhouse-server(DB::FunctionFactory::get(std::string const&, DB::Context const&) const+0x97) [0x13b9f47]
12:16:07 2. clickhouse-server(DB::ExpressionAnalyzer::getActionsImpl(std::shared_ptr<DB::IAST>, bool, bool, DB::ExpressionAnalyzer::ScopeStack&)+0xe11) [0x1289e01]
12:16:07 3. clickhouse-server(DB::ExpressionAnalyzer::getActionsImpl(std::shared_ptr<DB::IAST>, bool, bool, DB::ExpressionAnalyzer::ScopeStack&)+0x19ab) [0x128a99b]
12:16:07 4. clickhouse-server() [0x1291027]
12:16:07 5. clickhouse-server(DB::ExpressionAnalyzer::appendSelect(DB::ExpressionActionsChain&, bool)+0x78) [0x1292238]
12:16:07 6. clickhouse-server(DB::InterpreterSelectQuery::executeSingleQuery()+0x1dd) [0x12d503d]
12:16:07 7. clickhouse-server(DB::InterpreterSelectQuery::executeWithoutUnion()+0x1fd) [0x12d6c9d]
12:16:07 8. clickhouse-server(DB::InterpreterSelectQuery::execute()+0x30) [0x12d8a00]
12:16:07 9. clickhouse-server() [0x133a43d]
```

And this fix allows to disable timezone getting from CH. 
