### PR TITLE
Qs prewhere

### DIFF
--- a/docs/class_reference.md
+++ b/docs/class_reference.md
@@ -835,10 +835,10 @@ is equivalent to:
 Returns the whole query as a SQL string.
 
 
-#### conditions_as_sql()
+#### conditions_as_sql(prewhere=True)
 
 
-Returns the contents of the query's `WHERE` clause as a string.
+Returns the contents of the query's `WHERE` or `PREWHERE` clause as a string.
 
 
 #### count()
@@ -943,10 +943,10 @@ This method is not supported on `AggregateQuerySet`.
 Returns the whole query as a SQL string.
 
 
-#### conditions_as_sql()
+#### conditions_as_sql(prewhere=True)
 
 
-Returns the contents of the query's `WHERE` clause as a string.
+Returns the contents of the query's `WHERE` or `PREWHERE` clause as a string.
 
 
 #### count()

--- a/docs/querysets.md
+++ b/docs/querysets.md
@@ -17,21 +17,29 @@ The `filter` and `exclude` methods are used for filtering the matching instances
 
     >>> qs = Person.objects_in(database)
     >>> qs = qs.filter(first_name__startswith='V').exclude(birthday__lt='2000-01-01')
-    >>> qs.conditions_as_sql()
+    >>> qs.conditions_as_sql(qs._where)
     u"first_name LIKE 'V%' AND NOT (birthday < '2000-01-01')"
 
 It is possible to specify several fields to filter or exclude by:
 
     >>> qs = Person.objects_in(database).filter(last_name='Smith', height__gt=1.75)
-    >>> qs.conditions_as_sql()
+    >>> qs.conditions_as_sql(qs._where)
     u"last_name = 'Smith' AND height > 1.75"
 
 For filters with compound conditions you can use `Q` objects inside `filter` with overloaded operators `&` (AND), `|` (OR) and `~` (NOT):
 
     >>> qs = Person.objects_in(database).filter((Q(first_name='Ciaran', last_name='Carver') | Q(height_lte=1.8)) & ~Q(first_name='David'))
-    >>> qs.conditions_as_sql()
+    >>> qs.conditions_as_sql(qs._where)
     u"((first_name = 'Ciaran' AND last_name = 'Carver') OR height <= 1.8) AND (NOT (first_name = 'David'))"
 
+By default conditions from `filter` and `exclude` methods are add to `WHERE` clause. 
+For better aggregation performance you can add them to `PREWHERE` section using `prewhere=True` parameter
+
+    >>> qs = Person.objects_in(database)
+    >>> qs = qs.filter(first_name__startswith='V', prewhere=True)
+    >>> qs.conditions_as_sql(qs._prewhere)
+    u"first_name LIKE 'V%'"
+    
 There are different operators that can be used, by passing `<fieldname>__<operator>=<value>` (two underscores separate the field name from the operator). In case no operator is given, `eq` is used by default. Below are all the supported operators.
 
 | Operator       | Equivalent SQL                               | Comments                           |

--- a/docs/querysets.md
+++ b/docs/querysets.md
@@ -17,19 +17,19 @@ The `filter` and `exclude` methods are used for filtering the matching instances
 
     >>> qs = Person.objects_in(database)
     >>> qs = qs.filter(first_name__startswith='V').exclude(birthday__lt='2000-01-01')
-    >>> qs.conditions_as_sql(qs._where)
+    >>> qs.conditions_as_sql()
     u"first_name LIKE 'V%' AND NOT (birthday < '2000-01-01')"
 
 It is possible to specify several fields to filter or exclude by:
 
     >>> qs = Person.objects_in(database).filter(last_name='Smith', height__gt=1.75)
-    >>> qs.conditions_as_sql(qs._where)
+    >>> qs.conditions_as_sql()
     u"last_name = 'Smith' AND height > 1.75"
 
 For filters with compound conditions you can use `Q` objects inside `filter` with overloaded operators `&` (AND), `|` (OR) and `~` (NOT):
 
     >>> qs = Person.objects_in(database).filter((Q(first_name='Ciaran', last_name='Carver') | Q(height_lte=1.8)) & ~Q(first_name='David'))
-    >>> qs.conditions_as_sql(qs._where)
+    >>> qs.conditions_as_sql()
     u"((first_name = 'Ciaran' AND last_name = 'Carver') OR height <= 1.8) AND (NOT (first_name = 'David'))"
 
 By default conditions from `filter` and `exclude` methods are add to `WHERE` clause. 
@@ -37,7 +37,7 @@ For better aggregation performance you can add them to `PREWHERE` section using 
 
     >>> qs = Person.objects_in(database)
     >>> qs = qs.filter(first_name__startswith='V', prewhere=True)
-    >>> qs.conditions_as_sql(qs._prewhere)
+    >>> qs.conditions_as_sql(prewhere=True)
     u"first_name LIKE 'V%'"
     
 There are different operators that can be used, by passing `<fieldname>__<operator>=<value>` (two underscores separate the field name from the operator). In case no operator is given, `eq` is used by default. Below are all the supported operators.

--- a/docs/ref.md
+++ b/docs/ref.md
@@ -482,9 +482,9 @@ infi.clickhouse_orm.query
 #### QuerySet(model_cls, database)
 
 
-#### conditions_as_sql()
+#### conditions_as_sql(prewhere=True)
 
-Return the contents of the queryset's WHERE clause.
+Return the contents of the queryset's WHERE or `PREWHERE` clause.
 
 
 #### count()

--- a/src/infi/clickhouse_orm/query.py
+++ b/src/infi/clickhouse_orm/query.py
@@ -411,9 +411,10 @@ class QuerySet(object):
     def _filter_or_exclude(self, *q, **kwargs):
         reverse = kwargs.pop('reverse', False)
         prewhere = kwargs.pop('prewhere', False)
-        condition = copy(self._where_q)
+
         qs = copy(self)
 
+        condition = Q()
         for q_obj in q:
             condition &= q_obj
 
@@ -423,6 +424,7 @@ class QuerySet(object):
         if reverse:
             condition = ~condition
 
+        condition = copy(self._prewhere_q if prewhere else self._where_q) & condition
         if prewhere:
             qs._prewhere_q = condition
         else:

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -369,13 +369,13 @@ class AggregateTestCase(TestCaseWithData):
             the__next__number = Int32Field()
             engine = Memory()
         qs = Mdl.objects_in(self.database).filter(the__number=1)
-        self.assertEqual(qs.conditions_as_sql(), 'the__number = 1')
+        self.assertEqual(qs.conditions_as_sql(qs._where_q), 'the__number = 1')
         qs = Mdl.objects_in(self.database).filter(the__number__gt=1)
-        self.assertEqual(qs.conditions_as_sql(), 'the__number > 1')
+        self.assertEqual(qs.conditions_as_sql(qs._where_q), 'the__number > 1')
         qs = Mdl.objects_in(self.database).filter(the__next__number=1)
-        self.assertEqual(qs.conditions_as_sql(), 'the__next__number = 1')
+        self.assertEqual(qs.conditions_as_sql(qs._where_q), 'the__next__number = 1')
         qs = Mdl.objects_in(self.database).filter(the__next__number__gt=1)
-        self.assertEqual(qs.conditions_as_sql(), 'the__next__number > 1')
+        self.assertEqual(qs.conditions_as_sql(qs._where_q), 'the__next__number > 1')
 
 
 Color = Enum('Color', u'red blue green yellow brown white black')

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -417,13 +417,13 @@ class AggregateTestCase(TestCaseWithData):
             the__next__number = Int32Field()
             engine = Memory()
         qs = Mdl.objects_in(self.database).filter(the__number=1)
-        self.assertEqual(qs.conditions_as_sql(qs._where_q), 'the__number = 1')
+        self.assertEqual(qs.conditions_as_sql(), 'the__number = 1')
         qs = Mdl.objects_in(self.database).filter(the__number__gt=1)
-        self.assertEqual(qs.conditions_as_sql(qs._where_q), 'the__number > 1')
+        self.assertEqual(qs.conditions_as_sql(), 'the__number > 1')
         qs = Mdl.objects_in(self.database).filter(the__next__number=1)
-        self.assertEqual(qs.conditions_as_sql(qs._where_q), 'the__next__number = 1')
+        self.assertEqual(qs.conditions_as_sql(), 'the__next__number = 1')
         qs = Mdl.objects_in(self.database).filter(the__next__number__gt=1)
-        self.assertEqual(qs.conditions_as_sql(qs._where_q), 'the__next__number > 1')
+        self.assertEqual(qs.conditions_as_sql(), 'the__next__number > 1')
 
 
 Color = Enum('Color', u'red blue green yellow brown white black')

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -11,7 +11,7 @@ from datetime import date, datetime
 try:
     Enum # exists in Python 3.4+
 except NameError:
-    from enum import Enum # use the enum34 library instead
+    from enum import Enum  # use the enum34 library instead
 
 
 class QuerySetTestCase(TestCaseWithData):
@@ -28,6 +28,13 @@ class QuerySetTestCase(TestCaseWithData):
             logging.info('\t[%d]\t%s' % (count, instance.to_dict()))
         self.assertEqual(count, expected_count)
         self.assertEqual(qs.count(), expected_count)
+
+    def test_prewhere(self):
+        # We can't distinguish prewhere and where results, it affects performance only.
+        # So let's control prewhere acts like where does
+        qs = Person.objects_in(self.database)
+        self.assertTrue(qs.filter(first_name='Connor', prewhere=True))
+        self.assertFalse(qs.filter(first_name='Willy', prewhere=True))
 
     def test_no_filtering(self):
         qs = Person.objects_in(self.database)


### PR DESCRIPTION
1) Unified QuerySet `filter` and `exclude` methods,  so both can load *q and **kwargs at the same time and accept prewhere flag
2) Added ability to add prewhere clause in QuerySet.filter() and QuerySet.exclude() methods
  https://clickhouse.yandex/docs/en/query_language/select/#prewhere-clause
3) Added ability to check, if Q() object is empty (including bool check)
4) Added correct deepcopy for Q() and FOV() objects
5) Refactored QuerySet.as_sql() method:
   + don't add GROUP BY and WHERE if it's not needed
   + ability to add PREWHERE condition
   + Removing duplicate code from AggregateQuerySet, making as_sql() inheritence-based
6) Removed strange Q-objects list conditions, as it can be expressed with single Q-object.
7) Changed QuerySet `conditions_as_sql` so it accepts Q object to make sql from. This is used in building WHERE and PREWHERE clauses now, and can be possibly used for adding HAVING condition