### PR TITLE
Add the choice to set the compression codec for columns

### DIFF
--- a/docs/field_types.md
+++ b/docs/field_types.md
@@ -147,6 +147,34 @@ to `None`.
 
 NOTE: `ArrayField` of `NullableField` is not supported. Also `EnumField` cannot be nullable.
 
+Compression
+-----------
+You can specify a compression codec to use when writing into the database. Here are the different available :
+
+| Codec                | Argument                                 | Comment
+| -------------------- | ---------------------------------------- | ----------------------------------------------------
+| NONE                 | None                                     | No compression.
+| LZ4                  | None                                     | LZ4 compression.
+| LZ4HC(`level`)       | Possible level range: [3, 12].           | Default value: 9. The higher the better compression.
+| ZSTD(`level`)        | Possible level range: [1, 22].           | Default value: 1. The higher the better compression.
+| Delta(`delta_bytes`) | Possible delta_bytes range: 1, 2, 4 , 8. | Default value for `delta_bytes` is `sizeof(type)` if it is equal to 1, 2,4 or 8 and equals to 1 otherwise.
+
+Syntax example :
+
+```
+CREATE TABLE example
+(
+    dt Date CODEC(ZSTD),  // equivalent to dt Date CODEC(ZSTD(1))
+    ts DateTime CODEC(LZ4HC),  // equivalent to ts DateTime CODEC(LZ4HC(9))
+    path String
+)
+ENGINE = MergeTree()
+PARTITION BY tuple()
+ORDER BY dt
+```
+
+Note that you may need to install some libraries to use compression.
+
 Creating custom field types
 ---------------------------
 Sometimes it is convenient to use data types that are supported in Python, but have no corresponding column type in ClickHouse. In these cases it is possible to define a custom field class that knows how to convert the Pythonic object to a suitable representation in the database, and vice versa.

--- a/src/infi/clickhouse_orm/engines.py
+++ b/src/infi/clickhouse_orm/engines.py
@@ -110,6 +110,11 @@ class MergeTree(Engine):
                 params.append(self.sampling_expr)
             params.append('(%s)' % comma_join(self.order_by))
             params.append(str(self.index_granularity))
+        
+        # In ClickHouse 19.1.16 compression codecs were introduced
+        if db.server_version < (19, 1, 16):
+            for param in params:
+                param = param.split(' CODEC(')[0]
 
         return params
 
@@ -125,6 +130,11 @@ class CollapsingMergeTree(MergeTree):
     def _build_sql_params(self, db):
         params = super(CollapsingMergeTree, self)._build_sql_params(db)
         params.append(self.sign_col)
+
+        # In ClickHouse 19.1.16 compression codecs were introduced
+        if db.server_version < (19, 1, 16):
+            for param in params:
+                param = param.split(' CODEC(')[0]
         return params
 
 
@@ -141,6 +151,12 @@ class SummingMergeTree(MergeTree):
         params = super(SummingMergeTree, self)._build_sql_params(db)
         if self.summing_cols:
             params.append('(%s)' % comma_join(self.summing_cols))
+
+        # In ClickHouse 19.1.16 compression codecs were introduced
+        if db.server_version < (19, 1, 16):
+            for param in params:
+                param = param.split(' CODEC(')[0]
+
         return params
 
 
@@ -156,6 +172,12 @@ class ReplacingMergeTree(MergeTree):
         params = super(ReplacingMergeTree, self)._build_sql_params(db)
         if self.ver_col:
             params.append(self.ver_col)
+
+        # In ClickHouse 19.1.16 compression codecs were introduced
+        if db.server_version < (19, 1, 16):
+            for param in params:
+                param = param.split(' CODEC(')[0]
+
         return params
 
 


### PR DESCRIPTION
When you declare columns in a table, you can now specify which compression codec you want to use. This feature is only available for versions higher than 19.1.6.

I've also added explanations to `filed_types.md` to demonstrate how to use this new feature and what are the different choices.

It brings an answer to [this issue](https://github.com/Infinidat/infi.clickhouse_orm/issues/115).

Tests has been done - 0 E, 10 S