### PR TITLE
Fixed ignoring of negative enum values

### DIFF
--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -414,7 +414,7 @@ class BaseEnumField(Field):
         import re
         from enum import Enum
         members = {}
-        for match in re.finditer("'(\w+)' = (\d+)", db_type):
+        for match in re.finditer("'(\w+)' = (-?\d+)", db_type):
             members[match.group(1)] = int(match.group(2))
         enum_cls = Enum('AdHocEnum', members)
         field_class = Enum8Field if db_type.startswith('Enum8') else Enum16Field


### PR DESCRIPTION
ClickHouse supports:

8-bit Enum. It can contain up to 256 values enumerated in the [-128, 127] range.
16-bit Enum. It can contain up to 65536 values enumerated in the [-32768, 32767] range.

https://clickhouse.tech/docs/en/data_types/enum/