### PR TITLE
Uppercase and lowercase string enums behaviour updated.

### DIFF
--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -473,7 +473,11 @@ class BaseEnumField(Field):
                 except Exception:
                     return self.enum_cls(value)
             if isinstance(value, bytes):
-                return self.enum_cls[value.decode('UTF-8')]
+                decoded = value.decode('UTF-8')
+                try:
+                    return self.enum_cls[decoded]
+                except Exception:
+                    return self.enum_cls(decoded)
             if isinstance(value, int):
                 return self.enum_cls(value)
         except (KeyError, ValueError):

--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -468,7 +468,10 @@ class BaseEnumField(Field):
             return value
         try:
             if isinstance(value, str):
-                return self.enum_cls[value]
+                try:
+                    return self.enum_cls[value]
+                except Exception:
+                    return self.enum_cls(value)
             if isinstance(value, bytes):
                 return self.enum_cls[value.decode('UTF-8')]
             if isinstance(value, int):
@@ -665,4 +668,3 @@ class LowCardinalityField(Field):
 
 # Expose only relevant classes in import *
 __all__ = get_subclass_names(locals(), Field)
-


### PR DESCRIPTION
In some cases, there're situations like this.
let say we have a Enum class

```
class Foo(Enum):
    a = 'A'
```
and some values in CH are lowercase, some uppercase by reasons of various data pipelines

so, this PR supports this case by adding try-except.

In general, I think, initialization of Enum object as ```Foo(value)```  is a preferred way, rather than getting by dictionary notation
