### PR TITLE
Support for adding a column to the beginning of a table

### DIFF
--- a/src/infi/clickhouse_orm/migrations.py
+++ b/src/infi/clickhouse_orm/migrations.py
@@ -83,10 +83,12 @@ class AlterTable(ModelOperation):
             is_regular_field = not (field.materialized or field.alias)
             if name not in table_fields:
                 logger.info('        Add column %s', name)
-                assert prev_name, 'Cannot add a column to the beginning of the table'
                 cmd = 'ADD COLUMN %s %s' % (name, field.get_sql(db=database))
                 if is_regular_field:
-                    cmd += ' AFTER %s' % prev_name
+                    if prev_name is not None:
+                        cmd += ' AFTER %s' % prev_name
+                    else:
+                        cmd += ' FIRST'
                 self._alter_table(database, cmd)
 
             if is_regular_field:

--- a/src/infi/clickhouse_orm/migrations.py
+++ b/src/infi/clickhouse_orm/migrations.py
@@ -85,7 +85,7 @@ class AlterTable(ModelOperation):
                 logger.info('        Add column %s', name)
                 cmd = 'ADD COLUMN %s %s' % (name, field.get_sql(db=database))
                 if is_regular_field:
-                    if prev_name is not None:
+                    if prev_name:
                         cmd += ' AFTER %s' % prev_name
                     else:
                         cmd += ' FIRST'


### PR DESCRIPTION
Use the FIRST clause to add a column to the beginning of the table.

https://clickhouse.tech/docs/en/sql-reference/statements/alter/column/#alter_add-column