### PR TITLE
Clickhouse array string find end has wrong regular expression for missing case

### DIFF
--- a/src/infi/clickhouse_orm/utils.py
+++ b/src/infi/clickhouse_orm/utils.py
@@ -106,7 +106,7 @@ def parse_array(array_string):
             array_string = array_string[1:]
         elif array_string[0] == "'":
             # Start of quoted value, find its end
-            match = re.search(r"[^\\]'", array_string)
+            match = re.search(r"[^\\]'(?:,|])", array_string)
             if match is None:
                 raise ValueError('Missing closing quote: "%s"' % array_string)
             values.append(array_string[1 : match.start() + 1])


### PR DESCRIPTION
Old regular expression will missing the condition of the string has single quotes, which like ‘L'Oreal Paris' It will split into two words of "L" and "Oreal Paris'".
To judged as the  end of a independent word in array, not only the single quotation mark needs to be judged, but also whether it is end with ',' or ']' can be determined as the end of word.