### PR TITLE
debug: BaseTzInfo can only be imported from pytz.tzinfo

### DIFF
--- a/src/infi/clickhouse_orm/fields.py
+++ b/src/infi/clickhouse_orm/fields.py
@@ -6,7 +6,7 @@ from calendar import timegm
 from decimal import Decimal, localcontext
 from uuid import UUID
 from logging import getLogger
-from pytz import BaseTzInfo
+from pytz.tzinfo import BaseTzInfo
 from .utils import escape, parse_array, comma_join, string_or_func, get_subclass_names
 from .funcs import F, FunctionOperatorsMixin
 from ipaddress import IPv4Address, IPv6Address


### PR DESCRIPTION
'from pytz import BaseTzInfo' will cause an error: cannot import BaseTzInfo from pytz

This pull-request fixed this problem.