### PR TITLE
Fixed issue with double negation of Q objects

### DIFF
--- a/src/infi/clickhouse_orm/query.py
+++ b/src/infi/clickhouse_orm/query.py
@@ -262,7 +262,7 @@ class Q(object):
 
     def __invert__(self):
         q = copy(self)
-        q._negate = True
+        q._negate = not q._negate
         return q
 
     def __bool__(self):


### PR DESCRIPTION
Fixed a bug with double Q object negation:
`~(~Q(condition=True))` was equal to `~Q(condition=True)` before this fix