### PR TITLE
Fix pagination for models with alias fields

### DIFF
--- a/src/infi/clickhouse_orm/database.py
+++ b/src/infi/clickhouse_orm/database.py
@@ -319,7 +319,8 @@ class Database(object):
         elif page_num < 1:
             raise ValueError('Invalid page number: %d' % page_num)
         offset = (page_num - 1) * page_size
-        query = 'SELECT * FROM $table'
+        query = 'SELECT {} FROM $table'.format(", ".join(model_class.fields().keys()))
+        
         if conditions:
             if isinstance(conditions, Q):
                 conditions = conditions.to_sql(model_class)


### PR DESCRIPTION
Pagination is broken for models with alias fields due to https://github.com/ClickHouse/ClickHouse/issues/19659
This PR fixes this.