### PR TITLE
Fix tests crash with ClickHouse 22.8

### DIFF
--- a/src/infi/clickhouse_orm/models.py
+++ b/src/infi/clickhouse_orm/models.py
@@ -224,7 +224,10 @@ class ModelBase(type):
         # Tuples (poor man's version - convert to array)
         if db_type.startswith('Tuple'):
             types = [s.strip() for s in db_type[6 : -1].split(',')]
-            assert len(set(types)) == 1, 'No support for mixed types in tuples - ' + db_type
+            if len(types[0].split()) != 1:
+                raise NotImplementedError('No support for named tuples - %s' % db_type)
+            if len(set(types)) != 1:
+                raise NotImplementedError('No support for mixed types in tuples - %s' % db_type)
             inner_field = cls.create_ad_hoc_field(types[0])
             return orm_fields.ArrayField(inner_field)
         # FixedString

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -254,6 +254,8 @@ class DatabaseTestCase(TestCaseWithData):
         for row in self.database.select(query):
             if row.type.startswith('Map'):
                 continue  # Not supported yet
+            if 'Tuple' in row.type:
+                continue  # Not fully supported yet
             ModelBase.create_ad_hoc_field(row.type)
 
     def test_get_model_for_table(self):


### PR DESCRIPTION
Motivation:
ClickHouse 22.8 contains types `Tuple(UInt64, UInt64, UUID)` and `Array(Tuple(name String, previous_value String, new_value String, reason String))` in some system tables, which causes failed assertion in models.py during test execution.

https://fiddle.clickhouse.com/16ec71ab-592d-460d-bce3-e7bc4bbf59d9